### PR TITLE
[WIP]carrierwave update

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -14,5 +14,5 @@ CarrierWave.configure do |config|
   }
 
   config.fog_directory  = 'fleamarket80d'
-  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/leamarket80d'
+  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/fleamarket80d'
 end


### PR DESCRIPTION
## What
carrierwaveの記述が間違えていたため修正した。

  config.fog_directory  = 'leamarket80d'
  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/fleamarket80d'
↓下へ変更
  config.fog_directory  = 'fleamarket80d'
  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/fleamarket80d'

## Why
デプロイ担当者のS3へアクセス出来なかったため。