### PR TITLE
[WIP]ブランド入力とビュー崩れの修正

### DIFF
--- a/app/assets/stylesheets/new.scss
+++ b/app/assets/stylesheets/new.scss
@@ -339,8 +339,7 @@
             display: inline-block;
             position: relative;
             width: inherit;
-            select{
-              background-color: #fff;
+            input{
               border: 1px solid #ccc;
               border-radius: 4px;
               box-sizing: border-box;
@@ -350,7 +349,7 @@
               margin: 0;
               outline: none;
               padding: 0 16px;
-              width: inherit;
+              width: 100%;
             }
           }
         }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -67,7 +67,7 @@ class ItemsController < ApplicationController
     params.require(:item).permit(
     :name, :explain, :price, :status, 
     :postage, :prefecture,
-    :shipping_date, :category_id, 
+    :shipping_date, :category_id, :brand,
     item_imgs_attributes: [:image, :_destroy, :id]).merge(:user_id => current_user.id)
   end
 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -93,7 +93,7 @@
                 任意
             .item-detail__inner__brand
               .item-detail__inner__brand__inner
-                = f.text_field :brand, placeholder:"例）シャネル　※現段階では入力出来ません。",class: "select", disabled: "disable"
+                = f.text_field :brand, placeholder:"例）シャネル　※現段階では入力出来ません。", class: "input"
         .item-detail
           .item-detail__inner
             .item-detail__inner__name


### PR DESCRIPTION
# what
商品出品機能のブランドの入力を可能にした。
ビューの崩れを修正した。
itemsコントローラーに:brand追加、これによりDBへ情報を反映できる。
ビューはinputクラスを作成して他と同じになるように記述。
# Why
任意ではあるが、ブランドを入力する事によって検索の際ユーザーが探しやすいため。